### PR TITLE
Fix V595 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -775,8 +775,11 @@ scrot_find_window_by_property(Display * display,
                          &number_items, &after, &data);
     if (data)
       XFree(data);
-    if ((status == Success) && (type != (Atom) NULL))
-      child = children[i];
+    if ((status == Success) && (type != (Atom) NULL)) {
+      if (children) {
+          child = children[i];
+      }
+    }
   }
   for (i = 0; (i < number_children) && (child == None); i++)
     child = scrot_find_window_by_property(display, children[i], property);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Pointer was utilized before it was verified against nullptr.