### PR TITLE
Replace localtime with safer localtime_r

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,10 @@
 project('scrot', 'c',
         version : '0.9.0',
         license : 'MIT-feh',
-        default_options : ['c_std=c99', 'b_ndebug=if-release'],
+        default_options : ['c_std=c11', 'b_ndebug=if-release'],
         meson_version : '>= 0.49.0')
+
+add_global_arguments('-D_POSIX_C_SOURCE=200809L', language : 'c')
 
 configure_file(output : 'config.h',
   configuration : {

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ main(int argc,
   char *have_extension = NULL;
 
   time_t t;
-  struct tm *tm;
+  struct tm *tm = NULL;
 
   init_parse_options(argc, argv);
 
@@ -73,7 +73,7 @@ main(int argc,
     gib_eprintf("no image grabbed");
 
   time(&t); /* Get the time directly after the screenshot */
-  tm = localtime(&t);
+  tm = localtime_r(&t, tm);
 
   imlib_context_set_image(image);
   imlib_image_attach_data_value("quality", NULL, opt.quality, NULL);


### PR DESCRIPTION
Prevent static analysis tools from complaining. Use this as opportunity
to just use c11 and indicate POSIX portability.